### PR TITLE
Fix #6: Implement Core Block Vocabulary Definitions

### DIFF
--- a/blocks/blockquote/index.json
+++ b/blocks/blockquote/index.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://xats.org/core/blocks/blockquote",
+  "title": "Blockquote Block",
+  "description": "A block for extended quotations or excerpts",
+  "type": "object",
+  "properties": {
+    "blockType": {
+      "const": "https://xats.org/core/blocks/blockquote",
+      "description": "The URI identifier for this block type"
+    },
+    "content": {
+      "$ref": "https://xats.org/schemas/0.1.0/xats.json#/definitions/SemanticText",
+      "description": "The blockquote content as a SemanticText object"
+    }
+  },
+  "required": ["blockType", "content"],
+  "examples": [
+    {
+      "blockType": "https://xats.org/core/blocks/blockquote",
+      "content": {
+        "runs": [
+          {
+            "type": "text",
+            "text": "The cell is the basic structural and functional unit of all known living organisms. It is the smallest unit of life that is classified as a living thing, and is often called the building block of life."
+          }
+        ]
+      }
+    },
+    {
+      "blockType": "https://xats.org/core/blocks/blockquote",
+      "content": {
+        "runs": [
+          {
+            "type": "text",
+            "text": "As Darwin wrote: "
+          },
+          {
+            "type": "emphasis",
+            "text": "\"It is not the strongest of the species that survives, nor the most intelligent, but the one most responsive to change.\""
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/blocks/codeBlock/index.json
+++ b/blocks/codeBlock/index.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://xats.org/core/blocks/codeBlock",
+  "title": "Code Block",
+  "description": "A block for displaying code snippets with syntax highlighting",
+  "type": "object",
+  "properties": {
+    "blockType": {
+      "const": "https://xats.org/core/blocks/codeBlock",
+      "description": "The URI identifier for this block type"
+    },
+    "content": {
+      "type": "object",
+      "properties": {
+        "language": {
+          "type": "string",
+          "description": "The programming language of the code (e.g., 'python', 'javascript', 'java')"
+        },
+        "code": {
+          "type": "string",
+          "description": "The code snippet as a string"
+        },
+        "caption": {
+          "$ref": "https://xats.org/schemas/0.1.0/xats.json#/definitions/SemanticText",
+          "description": "Optional caption for the code block"
+        }
+      },
+      "required": ["code"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["blockType", "content"],
+  "examples": [
+    {
+      "blockType": "https://xats.org/core/blocks/codeBlock",
+      "content": {
+        "language": "python",
+        "code": "def fibonacci(n):\n    if n <= 1:\n        return n\n    return fibonacci(n-1) + fibonacci(n-2)\n\n# Calculate the 10th Fibonacci number\nresult = fibonacci(10)\nprint(f\"The 10th Fibonacci number is: {result}\")",
+        "caption": {
+          "runs": [
+            {
+              "type": "text",
+              "text": "Example 5.1: Recursive implementation of the Fibonacci sequence"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "blockType": "https://xats.org/core/blocks/codeBlock",
+      "content": {
+        "language": "javascript",
+        "code": "const quickSort = (arr) => {\n  if (arr.length <= 1) return arr;\n  \n  const pivot = arr[Math.floor(arr.length / 2)];\n  const left = arr.filter(x => x < pivot);\n  const middle = arr.filter(x => x === pivot);\n  const right = arr.filter(x => x > pivot);\n  \n  return [...quickSort(left), ...middle, ...quickSort(right)];\n};"
+      }
+    }
+  ]
+}

--- a/blocks/definition/index.json
+++ b/blocks/definition/index.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://xats.org/core/blocks/definition",
+  "title": "Definition Block",
+  "description": "A semantic callout block for defining key terms",
+  "type": "object",
+  "properties": {
+    "blockType": {
+      "const": "https://xats.org/core/blocks/definition",
+      "description": "The URI identifier for this block type"
+    },
+    "content": {
+      "type": "object",
+      "properties": {
+        "term": {
+          "type": "string",
+          "description": "The term being defined"
+        },
+        "definition": {
+          "$ref": "https://xats.org/schemas/0.1.0/xats.json#/definitions/SemanticText",
+          "description": "The definition of the term as a SemanticText object"
+        }
+      },
+      "required": ["term", "definition"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["blockType", "content"],
+  "examples": [
+    {
+      "blockType": "https://xats.org/core/blocks/definition",
+      "content": {
+        "term": "Mitochondria",
+        "definition": {
+          "runs": [
+            {
+              "type": "text",
+              "text": "Membrane-bound organelles found in eukaryotic cells that generate most of the cell's supply of "
+            },
+            {
+              "type": "emphasis",
+              "text": "adenosine triphosphate (ATP)"
+            },
+            {
+              "type": "text",
+              "text": ", used as a source of chemical energy."
+            }
+          ]
+        }
+      }
+    },
+    {
+      "blockType": "https://xats.org/core/blocks/definition",
+      "content": {
+        "term": "Photosynthesis",
+        "definition": {
+          "runs": [
+            {
+              "type": "text",
+              "text": "The process by which green plants and some other organisms use sunlight to synthesize foods from carbon dioxide and water."
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/blocks/example/index.json
+++ b/blocks/example/index.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://xats.org/core/blocks/example",
+  "title": "Example Block",
+  "description": "A semantic callout block for specific examples",
+  "type": "object",
+  "properties": {
+    "blockType": {
+      "const": "https://xats.org/core/blocks/example",
+      "description": "The URI identifier for this block type"
+    },
+    "content": {
+      "$ref": "https://xats.org/schemas/0.1.0/xats.json#/definitions/SemanticText",
+      "description": "The example content as a SemanticText object"
+    }
+  },
+  "required": ["blockType", "content"],
+  "examples": [
+    {
+      "blockType": "https://xats.org/core/blocks/example",
+      "content": {
+        "runs": [
+          {
+            "type": "strong",
+            "text": "Example:"
+          },
+          {
+            "type": "text",
+            "text": " Consider a ball thrown upward with an initial velocity of 20 m/s. Using the equation "
+          },
+          {
+            "type": "emphasis",
+            "text": "h = v€t - ½gt²"
+          },
+          {
+            "type": "text",
+            "text": ", we can calculate that it reaches a maximum height of 20.4 meters after 2.04 seconds."
+          }
+        ]
+      }
+    },
+    {
+      "blockType": "https://xats.org/core/blocks/example",
+      "content": {
+        "runs": [
+          {
+            "type": "text",
+            "text": "To find the derivative of "
+          },
+          {
+            "type": "emphasis",
+            "text": "f(x) = x²"
+          },
+          {
+            "type": "text",
+            "text": ", we apply the power rule: "
+          },
+          {
+            "type": "emphasis",
+            "text": "f'(x) = 2x"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/blocks/figure/index.json
+++ b/blocks/figure/index.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://xats.org/core/blocks/figure",
+  "title": "Figure Block",
+  "description": "A block for figures with captions, supporting images, diagrams, and charts",
+  "type": "object",
+  "properties": {
+    "blockType": {
+      "const": "https://xats.org/core/blocks/figure",
+      "description": "The URI identifier for this block type"
+    },
+    "content": {
+      "type": "object",
+      "properties": {
+        "refId": {
+          "type": "string",
+          "description": "Reference ID to a resource in the resources repository"
+        },
+        "caption": {
+          "$ref": "https://xats.org/schemas/0.1.0/xats.json#/definitions/SemanticText",
+          "description": "Caption for the figure"
+        },
+        "label": {
+          "type": "string",
+          "description": "Figure label (e.g., 'Figure 3.2')"
+        },
+        "altText": {
+          "type": "string",
+          "description": "Alternative text description for accessibility"
+        }
+      },
+      "required": ["refId", "caption", "label"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["blockType", "content"],
+  "examples": [
+    {
+      "blockType": "https://xats.org/core/blocks/figure",
+      "content": {
+        "refId": "mitosis-stages",
+        "label": "Figure 4.3",
+        "caption": {
+          "runs": [
+            {
+              "type": "text",
+              "text": "The stages of mitosis: "
+            },
+            {
+              "type": "strong",
+              "text": "(a)"
+            },
+            {
+              "type": "text",
+              "text": " prophase, "
+            },
+            {
+              "type": "strong",
+              "text": "(b)"
+            },
+            {
+              "type": "text",
+              "text": " metaphase, "
+            },
+            {
+              "type": "strong",
+              "text": "(c)"
+            },
+            {
+              "type": "text",
+              "text": " anaphase, and "
+            },
+            {
+              "type": "strong",
+              "text": "(d)"
+            },
+            {
+              "type": "text",
+              "text": " telophase"
+            }
+          ]
+        },
+        "altText": "Four microscope images showing the sequential stages of cell division in mitosis"
+      }
+    },
+    {
+      "blockType": "https://xats.org/core/blocks/figure",
+      "content": {
+        "refId": "carbon-cycle-diagram",
+        "label": "Figure 12.1",
+        "caption": {
+          "runs": [
+            {
+              "type": "text",
+              "text": "The global carbon cycle showing major reservoirs and annual fluxes in gigatons of carbon per year"
+            }
+          ]
+        },
+        "altText": "Diagram showing carbon movement between atmosphere, oceans, land, and geological reservoirs"
+      }
+    }
+  ]
+}

--- a/blocks/heading/index.json
+++ b/blocks/heading/index.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://xats.org/core/blocks/heading",
+  "title": "Heading Block",
+  "description": "A block for section headings and subheadings",
+  "type": "object",
+  "properties": {
+    "blockType": {
+      "const": "https://xats.org/core/blocks/heading",
+      "description": "The URI identifier for this block type"
+    },
+    "content": {
+      "type": "object",
+      "properties": {
+        "level": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 6,
+          "description": "The heading level (1-6, where 1 is the highest level)"
+        },
+        "text": {
+          "$ref": "https://xats.org/schemas/0.1.0/xats.json#/definitions/SemanticText",
+          "description": "The heading text content"
+        }
+      },
+      "required": ["level", "text"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["blockType", "content"],
+  "examples": [
+    {
+      "blockType": "https://xats.org/core/blocks/heading",
+      "content": {
+        "level": 1,
+        "text": {
+          "runs": [
+            {
+              "type": "text",
+              "text": "Introduction to Cell Biology"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "blockType": "https://xats.org/core/blocks/heading",
+      "content": {
+        "level": 3,
+        "text": {
+          "runs": [
+            {
+              "type": "text",
+              "text": "The "
+            },
+            {
+              "type": "emphasis",
+              "text": "Endoplasmic Reticulum"
+            },
+            {
+              "type": "text",
+              "text": " and Protein Synthesis"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/blocks/image/index.json
+++ b/blocks/image/index.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://xats.org/core/blocks/image",
+  "title": "Image Block",
+  "description": "A block for displaying images from the resources repository",
+  "type": "object",
+  "properties": {
+    "blockType": {
+      "const": "https://xats.org/core/blocks/image",
+      "description": "The URI identifier for this block type"
+    },
+    "content": {
+      "type": "object",
+      "properties": {
+        "refId": {
+          "type": "string",
+          "description": "Reference ID to an image resource in the resources repository"
+        },
+        "caption": {
+          "$ref": "https://xats.org/schemas/0.1.0/xats.json#/definitions/SemanticText",
+          "description": "Caption for the image as a SemanticText object"
+        }
+      },
+      "required": ["refId", "caption"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["blockType", "content"],
+  "examples": [
+    {
+      "blockType": "https://xats.org/core/blocks/image",
+      "content": {
+        "refId": "fig-cell-structure",
+        "caption": {
+          "runs": [
+            {
+              "type": "text",
+              "text": "Figure 3.1: Basic structure of a eukaryotic cell"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "blockType": "https://xats.org/core/blocks/image",
+      "content": {
+        "refId": "diagram-photosynthesis",
+        "caption": {
+          "runs": [
+            {
+              "type": "text",
+              "text": "The process of photosynthesis in "
+            },
+            {
+              "type": "emphasis",
+              "text": "C3 plants"
+            },
+            {
+              "type": "text",
+              "text": " showing light and dark reactions"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/blocks/list/index.json
+++ b/blocks/list/index.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://xats.org/core/blocks/list",
+  "title": "List Block",
+  "description": "A block for ordered or unordered lists",
+  "type": "object",
+  "properties": {
+    "blockType": {
+      "const": "https://xats.org/core/blocks/list",
+      "description": "The URI identifier for this block type"
+    },
+    "content": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ordered", "unordered"],
+          "description": "The type of list (ordered with numbers or unordered with bullets)"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "https://xats.org/schemas/0.1.0/xats.json#/definitions/SemanticText"
+          },
+          "description": "Array of list items, each as a SemanticText object"
+        }
+      },
+      "required": ["type", "items"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["blockType", "content"],
+  "examples": [
+    {
+      "blockType": "https://xats.org/core/blocks/list",
+      "content": {
+        "type": "unordered",
+        "items": [
+          {
+            "runs": [
+              { "type": "text", "text": "First item in the list" }
+            ]
+          },
+          {
+            "runs": [
+              { "type": "text", "text": "Second item with " },
+              { "type": "strong", "text": "bold text" }
+            ]
+          },
+          {
+            "runs": [
+              { "type": "text", "text": "Third item" }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "blockType": "https://xats.org/core/blocks/list",
+      "content": {
+        "type": "ordered",
+        "items": [
+          {
+            "runs": [
+              { "type": "text", "text": "Step one" }
+            ]
+          },
+          {
+            "runs": [
+              { "type": "text", "text": "Step two" }
+            ]
+          },
+          {
+            "runs": [
+              { "type": "text", "text": "Step three" }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/blocks/mathBlock/index.json
+++ b/blocks/mathBlock/index.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://xats.org/core/blocks/mathBlock",
+  "title": "Math Block",
+  "description": "A block for displaying mathematical equations and formulas",
+  "type": "object",
+  "properties": {
+    "blockType": {
+      "const": "https://xats.org/core/blocks/mathBlock",
+      "description": "The URI identifier for this block type"
+    },
+    "content": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "type": "string",
+          "enum": ["latex", "mathml", "asciimath"],
+          "description": "The format of the mathematical notation"
+        },
+        "math": {
+          "type": "string",
+          "description": "The mathematical expression in the specified format"
+        },
+        "display": {
+          "type": "string",
+          "enum": ["block", "inline"],
+          "default": "block",
+          "description": "Whether to display as a block equation or inline"
+        },
+        "caption": {
+          "$ref": "https://xats.org/schemas/0.1.0/xats.json#/definitions/SemanticText",
+          "description": "Optional caption or equation number"
+        }
+      },
+      "required": ["format", "math"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["blockType", "content"],
+  "examples": [
+    {
+      "blockType": "https://xats.org/core/blocks/mathBlock",
+      "content": {
+        "format": "latex",
+        "math": "E = mc^2",
+        "display": "block",
+        "caption": {
+          "runs": [
+            {
+              "type": "text",
+              "text": "Equation 1.1: Einstein's mass-energy equivalence"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "blockType": "https://xats.org/core/blocks/mathBlock",
+      "content": {
+        "format": "latex",
+        "math": "\\int_{-\\infty}^{\\infty} e^{-x^2} dx = \\sqrt{\\pi}",
+        "display": "block",
+        "caption": {
+          "runs": [
+            {
+              "type": "text",
+              "text": "The Gaussian integral"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "blockType": "https://xats.org/core/blocks/mathBlock",
+      "content": {
+        "format": "latex",
+        "math": "\\frac{d}{dx} \\sin(x) = \\cos(x)",
+        "display": "inline"
+      }
+    }
+  ]
+}

--- a/blocks/paragraph/index.json
+++ b/blocks/paragraph/index.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://xats.org/core/blocks/paragraph",
+  "title": "Paragraph Block",
+  "description": "A standard block for prose text content",
+  "type": "object",
+  "properties": {
+    "blockType": {
+      "const": "https://xats.org/core/blocks/paragraph",
+      "description": "The URI identifier for this block type"
+    },
+    "content": {
+      "$ref": "https://xats.org/schemas/0.1.0/xats.json#/definitions/SemanticText",
+      "description": "The paragraph text content as a SemanticText object"
+    }
+  },
+  "required": ["blockType", "content"],
+  "examples": [
+    {
+      "blockType": "https://xats.org/core/blocks/paragraph",
+      "content": {
+        "runs": [
+          {
+            "type": "text",
+            "text": "This is a simple paragraph with plain text."
+          }
+        ]
+      }
+    },
+    {
+      "blockType": "https://xats.org/core/blocks/paragraph",
+      "content": {
+        "runs": [
+          {
+            "type": "text",
+            "text": "This paragraph contains "
+          },
+          {
+            "type": "emphasis",
+            "text": "emphasized text"
+          },
+          {
+            "type": "text",
+            "text": " and a "
+          },
+          {
+            "type": "reference",
+            "text": "reference to another section",
+            "refId": "section-2.1"
+          },
+          {
+            "type": "text",
+            "text": "."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/blocks/quote/index.json
+++ b/blocks/quote/index.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://xats.org/core/blocks/quote",
+  "title": "Quote Block",
+  "description": "A semantic callout block for quotations",
+  "type": "object",
+  "properties": {
+    "blockType": {
+      "const": "https://xats.org/core/blocks/quote",
+      "description": "The URI identifier for this block type"
+    },
+    "content": {
+      "type": "object",
+      "properties": {
+        "quote": {
+          "$ref": "https://xats.org/schemas/0.1.0/xats.json#/definitions/SemanticText",
+          "description": "The quotation text"
+        },
+        "attribution": {
+          "$ref": "https://xats.org/schemas/0.1.0/xats.json#/definitions/SemanticText",
+          "description": "Optional attribution for the quote (author, source, etc.)"
+        }
+      },
+      "required": ["quote"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["blockType", "content"],
+  "examples": [
+    {
+      "blockType": "https://xats.org/core/blocks/quote",
+      "content": {
+        "quote": {
+          "runs": [
+            {
+              "type": "text",
+              "text": "The important thing is not to stop questioning. Curiosity has its own reason for existence."
+            }
+          ]
+        },
+        "attribution": {
+          "runs": [
+            {
+              "type": "text",
+              "text": "Albert Einstein"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "blockType": "https://xats.org/core/blocks/quote",
+      "content": {
+        "quote": {
+          "runs": [
+            {
+              "type": "text",
+              "text": "In science, there are no shortcuts to truth."
+            }
+          ]
+        },
+        "attribution": {
+          "runs": [
+            {
+              "type": "text",
+              "text": "Karl Popper, "
+            },
+            {
+              "type": "emphasis",
+              "text": "The Logic of Scientific Discovery"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/blocks/table/index.json
+++ b/blocks/table/index.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://xats.org/core/blocks/table",
+  "title": "Table Block",
+  "description": "A block for displaying tabular data",
+  "type": "object",
+  "properties": {
+    "blockType": {
+      "const": "https://xats.org/core/blocks/table",
+      "description": "The URI identifier for this block type"
+    },
+    "content": {
+      "type": "object",
+      "properties": {
+        "caption": {
+          "$ref": "https://xats.org/schemas/0.1.0/xats.json#/definitions/SemanticText",
+          "description": "Caption for the table"
+        },
+        "headers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of column header strings"
+        },
+        "rows": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "https://xats.org/schemas/0.1.0/xats.json#/definitions/SemanticText"
+            }
+          },
+          "description": "Array of rows, where each row is an array of SemanticText cells"
+        }
+      },
+      "required": ["caption", "headers", "rows"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["blockType", "content"],
+  "examples": [
+    {
+      "blockType": "https://xats.org/core/blocks/table",
+      "content": {
+        "caption": {
+          "runs": [
+            {
+              "type": "text",
+              "text": "Table 2.1: Comparison of prokaryotic and eukaryotic cells"
+            }
+          ]
+        },
+        "headers": ["Feature", "Prokaryotic", "Eukaryotic"],
+        "rows": [
+          [
+            {
+              "runs": [{ "type": "text", "text": "Nucleus" }]
+            },
+            {
+              "runs": [{ "type": "text", "text": "Absent" }]
+            },
+            {
+              "runs": [{ "type": "text", "text": "Present" }]
+            }
+          ],
+          [
+            {
+              "runs": [{ "type": "text", "text": "Cell size" }]
+            },
+            {
+              "runs": [{ "type": "text", "text": "1-10 ¼m" }]
+            },
+            {
+              "runs": [{ "type": "text", "text": "10-100 ¼m" }]
+            }
+          ],
+          [
+            {
+              "runs": [{ "type": "text", "text": "Organelles" }]
+            },
+            {
+              "runs": [{ "type": "text", "text": "None" }]
+            },
+            {
+              "runs": [{ "type": "text", "text": "Many types" }]
+            }
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/blocks/theorem/index.json
+++ b/blocks/theorem/index.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://xats.org/core/blocks/theorem",
+  "title": "Theorem Block",
+  "description": "A semantic callout block for theorems, laws, or principles",
+  "type": "object",
+  "properties": {
+    "blockType": {
+      "const": "https://xats.org/core/blocks/theorem",
+      "description": "The URI identifier for this block type"
+    },
+    "content": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "The label for the theorem (e.g., 'Theorem 4.1', 'Newton's First Law')"
+        },
+        "statement": {
+          "$ref": "https://xats.org/schemas/0.1.0/xats.json#/definitions/SemanticText",
+          "description": "The statement of the theorem, law, or principle"
+        }
+      },
+      "required": ["label", "statement"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["blockType", "content"],
+  "examples": [
+    {
+      "blockType": "https://xats.org/core/blocks/theorem",
+      "content": {
+        "label": "Theorem 3.2",
+        "statement": {
+          "runs": [
+            {
+              "type": "text",
+              "text": "For any right triangle, the square of the hypotenuse is equal to the sum of the squares of the other two sides: "
+            },
+            {
+              "type": "emphasis",
+              "text": "a² + b² = c²"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "blockType": "https://xats.org/core/blocks/theorem",
+      "content": {
+        "label": "Law of Conservation of Energy",
+        "statement": {
+          "runs": [
+            {
+              "type": "text",
+              "text": "Energy can neither be created nor destroyed; it can only be transformed from one form to another."
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/placeholders/bibliography/index.json
+++ b/placeholders/bibliography/index.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://xats.org/core/placeholders/bibliography",
+  "title": "Bibliography Placeholder",
+  "description": "A marker indicating where the formatted bibliography should be inserted",
+  "type": "object",
+  "properties": {
+    "blockType": {
+      "const": "https://xats.org/core/placeholders/bibliography",
+      "description": "The URI identifier for this placeholder type"
+    },
+    "content": {
+      "type": "object",
+      "description": "Empty object as placeholder for generated bibliography",
+      "additionalProperties": false
+    }
+  },
+  "required": ["blockType", "content"],
+  "examples": [
+    {
+      "blockType": "https://xats.org/core/placeholders/bibliography",
+      "content": {}
+    }
+  ]
+}

--- a/placeholders/index/index.json
+++ b/placeholders/index/index.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://xats.org/core/placeholders/index",
+  "title": "Index Placeholder",
+  "description": "A marker indicating where a generated index should be inserted",
+  "type": "object",
+  "properties": {
+    "blockType": {
+      "const": "https://xats.org/core/placeholders/index",
+      "description": "The URI identifier for this placeholder type"
+    },
+    "content": {
+      "type": "object",
+      "description": "Empty object as placeholder for generated index",
+      "additionalProperties": false
+    }
+  },
+  "required": ["blockType", "content"],
+  "examples": [
+    {
+      "blockType": "https://xats.org/core/placeholders/index",
+      "content": {}
+    }
+  ]
+}

--- a/placeholders/tableOfContents/index.json
+++ b/placeholders/tableOfContents/index.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://xats.org/core/placeholders/tableOfContents",
+  "title": "Table of Contents Placeholder",
+  "description": "A marker indicating where a generated Table of Contents should be inserted",
+  "type": "object",
+  "properties": {
+    "blockType": {
+      "const": "https://xats.org/core/placeholders/tableOfContents",
+      "description": "The URI identifier for this placeholder type"
+    },
+    "content": {
+      "type": "object",
+      "description": "Empty object as placeholder for generated content",
+      "additionalProperties": false
+    }
+  },
+  "required": ["blockType", "content"],
+  "examples": [
+    {
+      "blockType": "https://xats.org/core/placeholders/tableOfContents",
+      "content": {}
+    }
+  ]
+}

--- a/triggers/onAssessment/index.json
+++ b/triggers/onAssessment/index.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://xats.org/core/triggers/onAssessment",
+  "title": "On Assessment Trigger",
+  "description": "A trigger that fires based on assessment results",
+  "type": "object",
+  "properties": {
+    "triggerType": {
+      "const": "https://xats.org/core/triggers/onAssessment",
+      "description": "The URI identifier for this trigger type"
+    },
+    "sourceId": {
+      "type": "string",
+      "description": "The ID of the assessment that triggers this pathway"
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "assessmentType": {
+          "type": "string",
+          "enum": ["quiz", "test", "assignment", "selfAssessment", "peerAssessment"],
+          "description": "The type of assessment"
+        },
+        "scoreThreshold": {
+          "type": "object",
+          "properties": {
+            "min": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 100,
+              "description": "Minimum score percentage"
+            },
+            "max": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 100,
+              "description": "Maximum score percentage"
+            }
+          },
+          "description": "Score range that triggers this pathway"
+        },
+        "attemptNumber": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Which attempt number this trigger applies to"
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "required": ["triggerType"],
+  "examples": [
+    {
+      "triggerType": "https://xats.org/core/triggers/onAssessment",
+      "sourceId": "quiz-3.2",
+      "metadata": {
+        "assessmentType": "quiz",
+        "scoreThreshold": {
+          "min": 0,
+          "max": 70
+        },
+        "attemptNumber": 1
+      }
+    },
+    {
+      "triggerType": "https://xats.org/core/triggers/onAssessment",
+      "sourceId": "chapter-test-5",
+      "metadata": {
+        "assessmentType": "test",
+        "scoreThreshold": {
+          "min": 90,
+          "max": 100
+        }
+      }
+    }
+  ]
+}

--- a/triggers/onCompletion/index.json
+++ b/triggers/onCompletion/index.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://xats.org/core/triggers/onCompletion",
+  "title": "On Completion Trigger",
+  "description": "A trigger that fires when a section or unit is completed",
+  "type": "object",
+  "properties": {
+    "triggerType": {
+      "const": "https://xats.org/core/triggers/onCompletion",
+      "description": "The URI identifier for this trigger type"
+    },
+    "sourceId": {
+      "type": "string",
+      "description": "The ID of the object whose completion triggers this pathway"
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "completionCriteria": {
+          "type": "string",
+          "enum": ["viewed", "allActivitiesComplete", "assessmentPassed", "custom"],
+          "description": "The criteria for determining completion"
+        },
+        "customCriteria": {
+          "type": "string",
+          "description": "Custom completion criteria if completionCriteria is 'custom'"
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "required": ["triggerType"],
+  "examples": [
+    {
+      "triggerType": "https://xats.org/core/triggers/onCompletion",
+      "sourceId": "section-2.3",
+      "metadata": {
+        "completionCriteria": "viewed"
+      }
+    },
+    {
+      "triggerType": "https://xats.org/core/triggers/onCompletion",
+      "sourceId": "chapter-5",
+      "metadata": {
+        "completionCriteria": "allActivitiesComplete"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
This PR implements all core block vocabulary definitions for the xats schema, fixing issue #6. Previously, all vocabulary definition files were empty. This implementation provides comprehensive JSON Schema definitions for all core content blocks, placeholders, and triggers.

## Changes Made

### Core Block Vocabularies (12 types)
- **Text Blocks**: `paragraph`, `heading`, `blockquote`
- **Structured Content**: `list`, `table`, `figure`, `image`
- **Technical Content**: `codeBlock`, `mathBlock`
- **Semantic Callouts**: `definition`, `theorem`, `example`, `quote`

### Placeholder Vocabularies (3 types)
- `tableOfContents` - Marker for TOC generation
- `bibliography` - Marker for bibliography insertion
- `index` - Marker for index generation

### Trigger Vocabularies (2 types)
- `onCompletion` - Triggers based on content completion
- `onAssessment` - Triggers based on assessment scores

## Implementation Details

Each vocabulary definition includes:
- ✅ Valid JSON Schema structure with `$schema` and `$id`
- ✅ Clear property definitions with descriptions
- ✅ Proper constraints and validation rules
- ✅ Required fields specification
- ✅ References to `SemanticText` from main schema where appropriate
- ✅ Multiple comprehensive examples for each type

## Testing
All vocabulary files are valid JSON and follow the JSON Schema draft-07 specification. They properly reference the main xats schema definitions and maintain consistency with the documented core vocabularies.

## Related Issues
Closes #6