### PR TITLE
fix: update licenses to CC-BY-SA-4.0 and standardize documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,9 +9,16 @@ Welcome to the comprehensive documentation for the **Extensible Academic Textboo
 - [Architecture Overview](ARCHITECTURE.md) - Understand the design principles
 - [Authoring Guide](guides/authoring-guide.md) - Create your first xats document
 
-## Current Version: v0.3.0
+## Current Version: v0.4.0 (Development)
 
-**Latest Features:**
+**v0.4.0 Features (In Development):**
+- Modern monorepo infrastructure with Turborepo
+- TypeScript-first development with shared configurations
+- Comprehensive testing with Vitest
+- Component documentation with Storybook
+- Improved developer experience with standardized tooling
+
+**v0.3.0 Features (Stable):**
 - File modularity for large textbook organization
 - Enhanced internationalization with language and RTL support
 - Advanced indexing with IndexRun type

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "json-schema"
   ],
   "author": "xats.org",
-  "license": "MIT",
+  "license": "CC-BY-SA-4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/xats-org/core.git"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,7 @@
     "url": "git+https://github.com/xats-org/core.git",
     "directory": "packages/cli"
   },
-  "license": "MIT",
+  "license": "CC-BY-SA-4.0",
   "author": "xats Contributors",
   "type": "module",
   "exports": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -12,7 +12,7 @@
     "xats"
   ],
   "author": "xats.org",
-  "license": "MIT",
+  "license": "CC-BY-SA-4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/xats-org/core.git",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -18,7 +18,7 @@
     "url": "git+https://github.com/xats-org/core.git",
     "directory": "packages/examples"
   },
-  "license": "MIT",
+  "license": "CC-BY-SA-4.0",
   "author": "xats Contributors",
   "type": "module",
   "exports": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -68,7 +68,7 @@
     "schema"
   ],
   "author": "xats.org",
-  "license": "MIT",
+  "license": "CC-BY-SA-4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/xats-org/core.git",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -12,7 +12,7 @@
     "xats"
   ],
   "author": "xats.org",
-  "license": "MIT",
+  "license": "CC-BY-SA-4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/xats-org/core.git",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -18,7 +18,7 @@
     "url": "git+https://github.com/xats-org/core.git",
     "directory": "packages/renderer"
   },
-  "license": "MIT",
+  "license": "CC-BY-SA-4.0",
   "author": "xats Contributors",
   "type": "module",
   "exports": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -33,7 +33,7 @@
     "textbook"
   ],
   "author": "xats.org",
-  "license": "MIT",
+  "license": "CC-BY-SA-4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/xats-org/core.git",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -62,7 +62,7 @@
     "schema"
   ],
   "author": "xats.org",
-  "license": "MIT",
+  "license": "CC-BY-SA-4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/xats-org/core.git",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,7 +18,7 @@
     "url": "git+https://github.com/xats-org/core.git",
     "directory": "packages/utils"
   },
-  "license": "MIT",
+  "license": "CC-BY-SA-4.0",
   "author": "xats Contributors",
   "type": "module",
   "exports": {

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -50,7 +50,7 @@
     "textbook"
   ],
   "author": "xats.org",
-  "license": "MIT",
+  "license": "CC-BY-SA-4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/xats-org/core.git",

--- a/packages/vitest-config/package.json
+++ b/packages/vitest-config/package.json
@@ -14,7 +14,7 @@
     "xats"
   ],
   "author": "xats.org",
-  "license": "MIT",
+  "license": "CC-BY-SA-4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/xats-org/core.git",

--- a/packages/vocabularies/package.json
+++ b/packages/vocabularies/package.json
@@ -31,7 +31,7 @@
     "education"
   ],
   "author": "xats.org",
-  "license": "MIT",
+  "license": "CC-BY-SA-4.0",
   "dependencies": {
     "@xats/types": "workspace:*"
   },


### PR DESCRIPTION
## Summary
- Updated all license references from MIT to CC-BY-SA-4.0 to match LICENSE.md
- Removed unnecessary files from root directory (ISSUE-105-CLEANUP-PLAN.md, CHANGELOG-v0.4.0.md)
- Standardized documentation with v0.4.0 development status

## Changes
### License Updates
- Updated root package.json license field to CC-BY-SA-4.0
- Updated all 12 package subdirectories' package.json files to use CC-BY-SA-4.0

### File Cleanup
- Removed ISSUE-105-CLEANUP-PLAN.md (should never have been in root per CLAUDE.md)
- Removed CHANGELOG-v0.4.0.md (duplicate of CHANGELOG.md)

### Documentation Standardization
- Updated docs/index.md with current v0.4.0 development status
- Added clear distinction between v0.4.0 (development) and v0.3.0 (stable) features
- Maintained consistent formatting across all documentation

## Test Plan
- [x] All packages build successfully
- [x] Linting passes
- [x] Type checking passes
- [x] Documentation is accurate and consistent

Closes #143