### PR TITLE
docs: sync v0.4.0 documentation updates to main branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,8 +302,9 @@ Root
 ## Working with the Schema
 
 ### Schema Location
-- Current version: `/schemas/v0.1.0/xats.json`
-- Schema ID: `https://xats.org/schemas/0.1.0/xats.json`
+- Current stable version: `v0.3.0` (on main branch)
+- Active development: `v0.4.0` (monorepo structure)
+- Legacy versions: `v0.1.0`, `v0.2.0`
 
 ### Validation
 When working with xats documents, validate against the JSON Schema to ensure compliance.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Version](https://img.shields.io/badge/stable-v0.3.0-blue.svg)](https://github.com/xats-org/core/releases)
 [![Development](https://img.shields.io/badge/development-v0.4.0-orange.svg)](https://github.com/xats-org/core/tree/main)
 [![License: CC BY-SA 4.0](https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-sa/4.0/)
-[![CI Status](https://img.shields.io/github/actions/workflow/status/xats-org/core/ci.yml?branch=v0.2.0&label=CI)](https://github.com/xats-org/core/actions)
+[![CI Status](https://img.shields.io/github/actions/workflow/status/xats-org/core/ci.yml?branch=main&label=CI)](https://github.com/xats-org/core/actions)
 [![npm version](https://img.shields.io/npm/v/@xats-org/cli.svg)](https://www.npmjs.com/package/@xats-org/cli)
 
 **The Modern Standard for Academic and Educational Content**

--- a/docs/QUICKSTART_TUTORIAL.md
+++ b/docs/QUICKSTART_TUTORIAL.md
@@ -1,6 +1,6 @@
 # xats Quickstart Tutorial
 
-**Version:** 2.0 (for xats schema v0.2.0)
+**Version:** 3.0 (for xats schema v0.3.0)
 **Audience:** First-time authors and developers.
 
 ---
@@ -27,7 +27,7 @@ Before starting, ensure you have:
 
 To install the xats validation tool:
 ```bash
-npm install -g @xats-org/validator
+npm install -g @xats-org/cli
 ```
 
 ---
@@ -40,7 +40,7 @@ Every `xats` document starts with a root object that defines its version and cor
 
 ```json
 {
-  "schemaVersion": "0.2.0",
+  "schemaVersion": "0.3.0",
   "bibliographicEntry": {
     "id": "my-first-xats-book",
     "type": "book",
@@ -65,7 +65,7 @@ Every `xats` document starts with a root object that defines its version and cor
 ```
 
 ### Key Points:
-- **`schemaVersion`**: Always use "0.1.0" for the current schema
+- **`schemaVersion`**: Always use "0.3.0" for the current schema
 - **`bibliographicEntry`**: Uses CSL-JSON standard for metadata
 - **`subject`**: A string describing the main topic
 - **`bodyMatter`**: Contains the actual content (chapters or units)
@@ -80,7 +80,7 @@ Chapters are the primary organizational units in xats. Each chapter must have an
 
 ```json
 {
-  "schemaVersion": "0.2.0",
+  "schemaVersion": "0.3.0",
   "bibliographicEntry": {
     "id": "my-first-xats-book",
     "type": "book",
@@ -510,18 +510,18 @@ Validation ensures your document follows the xats schema correctly. Here's how t
 
 ```bash
 # Validate a single file
-xats-validate -f tutorial.xats.json
+xats validate -f tutorial.xats.json
 
 # Validate with verbose output (shows all checks)
-xats-validate -f tutorial.xats.json -v
+xats validate -f tutorial.xats.json -v
 
 # Validate all files in a directory
-xats-validate -d ./my-xats-documents/
+xats validate -d ./my-xats-documents/
 ```
 
 **Alternative: Using npm script**
 ```bash
-# If xats-validate is not installed globally
+# If xats is not installed globally
 npm run validate -- -f tutorial.xats.json
 ```
 
@@ -703,12 +703,12 @@ Common JSON mistakes:
 
 **Solution:**
 ```bash
-npm install -g @xats-org/validator
+npm install -g @xats-org/cli
 ```
 
 If you get permission errors:
 ```bash
-sudo npm install -g @xats-org/validator
+sudo npm install -g @xats-org/cli
 ```
 
 ### Issue: "Schema validation failed with no specific error"
@@ -754,7 +754,7 @@ sudo npm install -g @xats-org/validator
 **Solution:**
 ```bash
 # Increase timeout and use streaming validation
-xats-validate -f large-book.xats.json --timeout 30000 --stream
+xats validate -f large-book.xats.json --timeout 30000 --stream
 ```
 
 ---
@@ -785,7 +785,7 @@ To explore an example:
 cat examples/single-chapter.xats.json
 
 # Validate it
-xats-validate -f examples/single-chapter.xats.json
+xats validate -f examples/single-chapter.xats.json
 
 # Copy it as a starting point
 cp examples/single-chapter.xats.json my-document.xats.json
@@ -849,10 +849,10 @@ xats is designed for extensibility. Consider building:
 Make validation part of your workflow:
 ```bash
 # Add to your build process
-npm run build && xats-validate -d ./content/
+npm run build && xats validate -d ./content/
 
 # Git pre-commit hook
-xats-validate -f *.xats.json || exit 1
+xats validate -f *.xats.json || exit 1
 ```
 
 ---
@@ -907,10 +907,10 @@ xats-validate -f *.xats.json || exit 1
 
 ### Validation Commands
 ```bash
-xats-validate -f file.json        # Single file
-xats-validate -d directory/       # Directory
-xats-validate -f file.json -v     # Verbose
-xats-validate --examples-only     # Examples only
+xats validate -f file.json        # Single file
+xats validate -d directory/       # Directory
+xats validate -f file.json -v     # Verbose
+xats validate --examples-only     # Examples only
 ```
 
 ---

--- a/docs/guides/accessibility-guide.md
+++ b/docs/guides/accessibility-guide.md
@@ -15,7 +15,7 @@ The xats standard is designed with accessibility as a core principle. This guide
 
 ## WCAG 2.1 AA Compliance
 
-xats v0.2.0 provides 100% WCAG 2.1 AA compliance through:
+xats v0.3.0 provides 100% WCAG 2.1 AA compliance through:
 
 ### 1. Perceivable Content
 
@@ -51,7 +51,7 @@ Every document and content element must identify its language:
 
 ```json
 {
-  "schemaVersion": "0.2.0",
+  "schemaVersion": "0.3.0",
   "language": "en-US",  // Document-level language
   "bodyMatter": {
     "contents": [
@@ -275,7 +275,7 @@ Provide skip links for repetitive content:
 Use the xats validator with accessibility checks:
 
 ```bash
-xats-validate --accessibility my-document.json
+xats validate --accessibility my-document.json
 ```
 
 ### Manual Testing

--- a/docs/guides/authoring-guide.md
+++ b/docs/guides/authoring-guide.md
@@ -1,6 +1,6 @@
 # xats Authoring Guide
 
-**Version:** 2.0 (for xats schema v0.2.0)
+**Version:** 3.0 (for xats schema v0.3.0)
 **Audience:** Authors, Instructional Designers, and AI Engineers
 
 ---
@@ -9,7 +9,7 @@
 
 This guide provides best practices for creating effective, semantically rich, and machine-readable documents using the **xats** standard. While the schema defines *what* is possible, this guide explains *how* to use the features to achieve the desired pedagogical and technical outcomes.
 
-**New in v0.2.0:** This guide now covers the comprehensive assessment framework, LTI 1.3 integration, accessibility features, and rights management capabilities.
+**New in v0.3.0:** This guide now covers the comprehensive assessment framework, LTI 1.3 integration, accessibility features, rights management capabilities, and enhanced monorepo tooling.
 
 ## 2. Thinking in `xats`: The Author's Mindset
 
@@ -20,9 +20,9 @@ This guide provides best practices for creating effective, semantically rich, an
 
 ## 3. Best Practices by Feature
 
-### a. Assessment Framework (New in v0.2.0)
+### a. Assessment Framework (Enhanced in v0.3.0)
 
-The v0.2.0 assessment framework provides powerful tools for creating pedagogically sound assessments with built-in analytics and accessibility support.
+The v0.3.0 assessment framework provides powerful tools for creating pedagogically sound assessments with built-in analytics and accessibility support.
 
 #### Assessment Types
 
@@ -119,9 +119,9 @@ The v0.2.0 assessment framework provides powerful tools for creating pedagogical
 - **Set Appropriate Scoring:** Configure `scoring` with proper point values, attempt limits, and penalty structures
 - **Include Helpful Hints:** Use the `hints` array in feedback to provide progressive scaffolding
 
-### b. Accessibility Best Practices (Enhanced in v0.2.0)
+### b. Accessibility Best Practices (Enhanced in v0.3.0)
 
-The v0.2.0 accessibility framework ensures WCAG 2.1 AA compliance and universal design principles.
+The v0.3.0 accessibility framework ensures WCAG 2.1 AA compliance and universal design principles.
 
 #### Language and Internationalization
 ```json
@@ -152,7 +152,7 @@ The v0.2.0 accessibility framework ensures WCAG 2.1 AA compliance and universal 
 - **Support Cognitive Accessibility:** Include `cognitiveSupport` metadata with reading levels and complexity indicators
 - **Enable Skip Navigation:** Use `SkipNavigationContent` blocks for keyboard accessibility (WCAG 2.4.1)
 
-### c. LTI 1.3 Integration (New in v0.2.0)
+### c. LTI 1.3 Integration (Enhanced in v0.3.0)
 
 The LTI 1.3 framework enables seamless integration with Learning Management Systems.
 
@@ -183,7 +183,7 @@ The LTI 1.3 framework enables seamless integration with Learning Management Syst
 - **Set Appropriate Permissions:** Configure NRPS (Names and Role Provisioning Services) for proper user management
 - **Test Across Platforms:** Validate integration with major LMS platforms (Canvas, Blackboard, Moodle)
 
-### d. Rights Management (New in v0.2.0)
+### d. Rights Management (Enhanced in v0.3.0)
 
 The comprehensive rights framework supports commercial publishing and academic integrity.
 
@@ -210,7 +210,7 @@ The comprehensive rights framework supports commercial publishing and academic i
 }
 ```
 
-### e. Content Pathways (Enhanced in v0.2.0)
+### e. Content Pathways (Enhanced in v0.3.0)
 
 Pathways now support assessment-based branching for adaptive learning.
 

--- a/docs/guides/lti-integration.md
+++ b/docs/guides/lti-integration.md
@@ -32,7 +32,7 @@ LTI 1.3 is the latest version of the IMS Global Learning Tools Interoperability 
 
 ```json
 {
-  "schemaVersion": "0.2.0",
+  "schemaVersion": "0.3.0",
   "extensions": {
     "https://xats.org/extensions/lti": {
       "configuration": {

--- a/docs/guides/migration-guide.md
+++ b/docs/guides/migration-guide.md
@@ -233,16 +233,16 @@ Validate your migrated document:
 
 ```bash
 # Install the latest version
-npm install -g @xats-org/core@latest
+npm install -g @xats-org/cli@latest
 
 # Validate your document
-xats-validate my-document.json
+xats validate my-document.json
 ```
 
 ### Programmatic Validation
 
 ```javascript
-import { validateDocument } from '@xats-org/core';
+import { validateDocument } from '@xats-org/cli';
 
 const document = require('./my-document.json');
 const { valid, errors } = await validateDocument(document);
@@ -898,29 +898,29 @@ Integrate reflection opportunities throughout your content:
 
 ```bash
 # Validate v0.3.0 documents with all features
-xats-validate --version 0.3.0 document.json
+xats validate --version 0.3.0 document.json
 
 # Check modular document integrity
-xats-validate --modular --verify-refs document.json
+xats validate --modular --verify-refs document.json
 
 # Validate accessibility compliance
-xats-validate --accessibility --wcag-level AA document.json
+xats validate --accessibility --wcag-level AA document.json
 
 # Check internationalization support
-xats-validate --i18n --check-language-tags document.json
+xats validate --i18n --check-language-tags document.json
 ```
 
 #### Modularization Helper
 
 ```bash
 # Split large document by chapters
-xats-modularize textbook.json --strategy=by-chapter --output-dir=./chapters
+xats modularize textbook.json --strategy=by-chapter --output-dir=./chapters
 
 # Generate index from IndexRun markers
-xats-generate-index textbook.json --output=generated-index.json
+xats generate-index textbook.json --output=generated-index.json
 
 # Extract translatable content
-xats-extract-i18n textbook.json --target-language=es --output=translation-strings.json
+xats extract-i18n textbook.json --target-language=es --output=translation-strings.json
 ```
 
 ### Recommended Migration Steps
@@ -990,26 +990,26 @@ The xats project provides migration utilities:
 
 ```bash
 # Install migration tools
-npm install -g @xats-org/migration-tools
+npm install -g @xats-org/cli
 
 # Migrate document from v0.1.0 to v0.2.0
-xats-migrate --from 0.1.0 --to 0.2.0 document.json
+xats migrate --from 0.1.0 --to 0.2.0 document.json
 
 # Validate migration result
-xats-validate document.json
+xats validate document.json
 ```
 
 ### Schema-Specific Validators
 
 ```bash
 # Validate against specific schema version
-xats-validate --schema 0.3.0 document.json
+xats validate --schema 0.3.0 document.json
 
 # Check accessibility compliance
-xats-validate --wcag-check document.json
+xats validate --wcag-check document.json
 
 # Validate LTI configuration
-xats-validate --lti-check document.json
+xats validate --lti-check document.json
 ```
 
 ### Custom Migration Scripts
@@ -1065,16 +1065,16 @@ Before starting migration:
 
 ```bash
 # Complete validation suite
-xats-validate --comprehensive document.json
+xats validate --comprehensive document.json
 
 # Accessibility-specific validation
-xats-validate --accessibility document.json
+xats validate --accessibility document.json
 
 # Assessment validation
-xats-validate --assessments document.json
+xats validate --assessments document.json
 
 # Extension validation
-xats-validate --extensions document.json
+xats validate --extensions document.json
 ```
 
 ## Common Migration Issues

--- a/docs/integration/lti-1.3-integration-guide.md
+++ b/docs/integration/lti-1.3-integration-guide.md
@@ -29,7 +29,7 @@ Add LTI configuration to the document root `extensions` property:
 
 ```json
 {
-  "schemaVersion": "0.2.0",
+  "schemaVersion": "0.3.0",
   "extensions": {
     "ltiConfiguration": {
       "toolTitle": "xats Chemistry Textbook",

--- a/docs/specs/version-compatibility-matrix.md
+++ b/docs/specs/version-compatibility-matrix.md
@@ -187,7 +187,7 @@ To take advantage of new features, manual updates are required:
 ```json
 // Add accessibility metadata
 {
-  "schemaVersion": "0.2.0",
+  "schemaVersion": "0.3.0",
   "language": "en-US",
   "accessibility": {
     "wcagLevel": "AA",


### PR DESCRIPTION
## Summary

This PR syncs documentation updates from the v0.4.0 branch to main, ensuring all documentation correctly reflects that v0.3.0 is the current stable release and v0.4.0 is in development.

These changes were originally committed to v0.4.0 branch in PR #151 but need to be brought to main to maintain consistency.

## Changes

This cherry-picks commit d5a10e6 from v0.4.0 branch, which updates:

- **Schema version references**: Updates examples from 0.1.0/0.2.0 to 0.3.0
- **CLI package names**: Changes from @xats-org/validator to @xats-org/cli  
- **CLI commands**: Updates from hyphenated syntax (xats-validate) to subcommand syntax (xats validate)
- **Version status**: Marks v0.3.0 as stable, v0.4.0 as development
- **CI badge**: Fixes badge to point to main branch instead of v0.2.0

## Files Modified (9 files)

- `CLAUDE.md` - Schema location section updated
- `README.md` - CI badge and version references fixed
- `docs/QUICKSTART_TUTORIAL.md` - Updated to v3.0 for schema v0.3.0
- `docs/guides/accessibility-guide.md` - Version references updated
- `docs/guides/authoring-guide.md` - Version and feature descriptions updated
- `docs/guides/lti-integration.md` - Schema version in examples updated
- `docs/guides/migration-guide.md` - CLI package and commands updated
- `docs/integration/lti-1.3-integration-guide.md` - Schema version updated
- `docs/specs/version-compatibility-matrix.md` - Schema version in examples updated

## Test Plan

- [x] All changes are documentation-only
- [x] No functional code changes
- [x] Cherry-picked cleanly from v0.4.0 branch
- [x] Verified all version references are consistent

## Related

- Original PR: #151
- Issue: #150

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>