### PR TITLE
fix: configure Dependabot to ignore major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,10 +28,10 @@ updates:
     reviewers:
       - "xats-org/maintainers"
     milestone: 4  # v0.4.0 milestone
-    # Ignore individual package updates - handled by root
+    # Ignore major version updates to prevent breaking changes
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]  # Ignore patch updates
+        update-types: ["version-update:semver-major"]  # Ignore major updates
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
Updates Dependabot configuration to ignore major version updates instead of patch updates, preventing PRs with breaking changes.

## Problem
Dependabot was creating PRs for major version updates (like those in #154 and #155) which introduce breaking changes:
- Storybook 7 → 9
- React 18 → 19
- ESLint 8 → 9
- Other major version bumps

These require significant migration effort and should be done manually with proper testing.

## Solution
Changed `.github/dependabot.yml` to:
- **Before**: Ignored patch updates (`version-update:semver-patch`)
- **After**: Ignore major updates (`version-update:semver-major`)

## Impact
- ✅ Dependabot will still create PRs for minor and patch updates (backward compatible)
- ✅ No more automatic PRs for breaking changes
- ✅ Major version upgrades can be done manually when ready
- ✅ Reduces noise and prevents accidental breaking changes

## Related Issues
- Addresses the concerns from closed PRs #154 and #155

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>