### PR TITLE
chore: sync v0.4.0 branch to main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,10 +28,10 @@ updates:
     reviewers:
       - "xats-org/maintainers"
     milestone: 4  # v0.4.0 milestone
-    # Ignore individual package updates - handled by root
+    # Ignore major version updates to prevent breaking changes
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]  # Ignore patch updates
+        update-types: ["version-update:semver-major"]  # Ignore major updates
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
- Syncing v0.4.0 branch changes to main to ensure both branches are at the same commit level
- Brings in Dependabot configuration updates and merge commits from recent PRs

## Changes
- Dependabot configuration to ignore major version updates
- Merge commits from PRs #170 and #171
- Ensures main and v0.4.0 are synchronized

## Test plan
- [x] Verified all changes are from v0.4.0 branch
- [x] No conflicts with main
- [x] CI checks should pass

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>