### PR TITLE
fix: resolve TruffleHog CI error when BASE and HEAD are identical

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -95,11 +95,33 @@ jobs:
       with:
         fetch-depth: 0  # Full history for better detection
     
+    - name: Check if TruffleHog should run
+      id: should_scan
+      run: |
+        # Get the current branch name
+        CURRENT_BRANCH="${GITHUB_REF#refs/heads/}"
+        DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
+        
+        # For push events to the default branch, compare with the previous commit
+        if [[ "${{ github.event_name }}" == "push" && "$CURRENT_BRANCH" == "$DEFAULT_BRANCH" ]]; then
+          echo "scan_base=${{ github.event.before }}" >> $GITHUB_OUTPUT
+          echo "should_run=true" >> $GITHUB_OUTPUT
+        # For pull requests, compare with the base branch
+        elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          echo "scan_base=${{ github.event.pull_request.base.sha }}" >> $GITHUB_OUTPUT
+          echo "should_run=true" >> $GITHUB_OUTPUT
+        # For other push events, compare with the default branch
+        else
+          echo "scan_base=$DEFAULT_BRANCH" >> $GITHUB_OUTPUT
+          echo "should_run=true" >> $GITHUB_OUTPUT
+        fi
+    
     - name: TruffleHog OSS
+      if: steps.should_scan.outputs.should_run == 'true'
       uses: trufflesecurity/trufflehog@main
       with:
         path: ./
-        base: ${{ github.event.repository.default_branch }}
+        base: ${{ steps.should_scan.outputs.scan_base }}
         head: HEAD
         extra_args: --debug --only-verified
 


### PR DESCRIPTION
## Summary

This PR fixes the TruffleHog secret scanning CI failure that occurs when pushing directly to the main branch.

## Problem

The TruffleHog secret scanner was failing with the error:
```
BASE and HEAD commits are the same. TruffleHog won't scan anything.
```

This happens when:
- Pushing directly to the default branch
- The base reference and HEAD point to the same commit

## Solution

Added intelligent conditional logic to determine the correct base for comparison:

1. **For pushes to the default branch**: Compare with the previous commit (`github.event.before`)
2. **For pull requests**: Compare with the base branch SHA
3. **For other pushes**: Compare with the default branch

This ensures TruffleHog always has different commits to compare, preventing the error.

## Changes

- Modified `.github/workflows/security.yml` to add a pre-check step
- The check determines the appropriate base commit based on the event type
- TruffleHog now uses the dynamically determined base reference

## Testing

- ✅ Works for direct pushes to main (compares with previous commit)
- ✅ Works for pull requests (compares with base branch)
- ✅ Works for feature branch pushes (compares with default branch)

## Related Issues

Fixes the CI failure seen on the main branch after merging PR #202.

🤖 Generated with [Claude Code](https://claude.ai/code)