### PR TITLE
fix: standardize CodeQL language configuration on v0.4.0 branch

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -64,7 +64,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['javascript', 'typescript']
+        # Use combined javascript-typescript language for consistency across branches
+        language: ['javascript-typescript']
     
     steps:
     - name: Checkout repository


### PR DESCRIPTION
## Summary

This PR standardizes the CodeQL language configuration on the v0.4.0 branch to resolve the 'configurations not found' warnings.

## Changes
- Changed from separate  and  languages to combined 
- Aligns with main branch (already fixed) and v0.5.0 branch configurations
- Maintains same security coverage with more efficient single analysis

## Root Cause
CodeQL was reporting '2 configurations present on refs/heads/main were not found' because:
- Main branch had separate  and  configurations
- v0.5.0 and other branches used combined  configuration
- This mismatch caused GitHub to report missing configurations when comparing branches

## Fix Verification
- ✅ Main branch: Updated to use  
- ✅ v0.5.0 branch: Already uses 
- 🔄 v0.4.0 branch: This PR updates to use 

After this PR merges, all branches will have consistent CodeQL configurations and the warnings will be resolved.

## Testing
- CodeQL analysis will run with the same security coverage
- Single analysis is more efficient than separate javascript/typescript analyses
- GitHub's CodeQL action officially recommends the combined approach for TypeScript projects