### PR TITLE
feat: add npm-production deployment tracking to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
       issues: write
       pull-requests: write
       id-token: write
+      deployments: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v5
@@ -58,6 +59,44 @@ jobs:
       - name: Run Tests
         run: pnpm test
 
+      - name: Create NPM Deployment
+        id: deployment
+        if: github.ref == 'refs/heads/main'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              const deployment = await github.rest.repos.createDeployment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: context.sha,
+                environment: 'npm-production',
+                description: 'Publishing packages to npm',
+                auto_merge: false,
+                required_contexts: [],
+                production_environment: true
+              });
+              
+              if (deployment.status === 201) {
+                core.setOutput('id', deployment.data.id);
+                console.log(`Created deployment ${deployment.data.id}`);
+                
+                // Set initial status to in_progress
+                await github.rest.repos.createDeploymentStatus({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  deployment_id: deployment.data.id,
+                  state: 'in_progress',
+                  description: 'Publishing packages to npm...',
+                  environment_url: 'https://www.npmjs.com/org/xats-org'
+                });
+              }
+            } catch (error) {
+              console.log('Could not create deployment, likely due to branch protection.');
+              console.log('Continuing without deployment tracking.');
+              core.setOutput('id', '');
+            }
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
@@ -70,6 +109,47 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Update Deployment Status
+        if: steps.changesets.outputs.published == 'true' && steps.deployment.outputs.id != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deploymentId = ${{ steps.deployment.outputs.id }};
+            const publishedPackages = ${{ steps.changesets.outputs.publishedPackages }};
+            
+            // Extract version from first package
+            const version = publishedPackages[0]?.version || 'unknown';
+            const packageCount = publishedPackages.length;
+            
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deploymentId,
+              state: 'success',
+              description: `Successfully published ${packageCount} packages (v${version})`,
+              environment_url: 'https://www.npmjs.com/org/xats-org'
+            });
+            
+            console.log(`Updated deployment ${deploymentId} to success`);
+
+      - name: Update Deployment Status on Failure
+        if: failure() && steps.deployment.outputs.id != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deploymentId = ${{ steps.deployment.outputs.id }};
+            
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deploymentId,
+              state: 'failure',
+              description: 'Failed to publish packages to npm',
+              environment_url: 'https://www.npmjs.com/org/xats-org'
+            });
+            
+            console.log(`Updated deployment ${deploymentId} to failure`);
 
       - name: Post Release Steps
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Summary
This PR adds GitHub deployment tracking for npm package publishing in the release workflow.

## Changes
- Added `deployments: write` permission to the release workflow
- Create a deployment record when publishing to npm from main branch
- Update deployment status based on publish success or failure
- Include package count and version in deployment description

## Benefits
- npm-production deployments will now show correctly on GitHub's deployment page
- Provides visibility into npm publishing history
- Matches the deployment tracking pattern used by other environments (e.g., github-pages)

## Testing
- YAML syntax validated with `yaml-lint`
- Deployment creation wrapped in try-catch to avoid blocking releases
- Deployment tracking only enabled for main branch releases

Fixes the issue where npm-production showed as 'failed' on the deployments page despite successful publishes.